### PR TITLE
updating shebang to support running FSF in a virtualenv

### DIFF
--- a/fsf-client/conf/config.py
+++ b/fsf-client/conf/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Basic configuration attributes for scanner client.
 #

--- a/fsf-client/fsf_client.py
+++ b/fsf-client/fsf_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # FSF Client for sending information and generating a report
 #

--- a/fsf-server/conf/config.py
+++ b/fsf-server/conf/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Basic configuration attributes for scanner. Used as default
 # unless the user overrides them. 

--- a/fsf-server/conf/disposition.py
+++ b/fsf-server/conf/disposition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # This is the Python 'module' that contains the 
 # disposition criteria for Yara and jq filters the scanner framework

--- a/fsf-server/main.py
+++ b/fsf-server/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Listen, accept, and disposition incomming files.
 #

--- a/fsf-server/modules/EXTRACT_CAB.py
+++ b/fsf-server/modules/EXTRACT_CAB.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Unpack CAB using cabextract as a helper.

--- a/fsf-server/modules/EXTRACT_EMBEDDED.py
+++ b/fsf-server/modules/EXTRACT_EMBEDDED.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Company: Emerson

--- a/fsf-server/modules/EXTRACT_GZIP.py
+++ b/fsf-server/modules/EXTRACT_GZIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Extract and process file contained within a GZIP archive 

--- a/fsf-server/modules/EXTRACT_HEXASCII_PE.py
+++ b/fsf-server/modules/EXTRACT_HEXASCII_PE.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Binary convert on hexascii printables contained within a stream 

--- a/fsf-server/modules/EXTRACT_RAR.py
+++ b/fsf-server/modules/EXTRACT_RAR.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Company: Emerson

--- a/fsf-server/modules/EXTRACT_RTF_OBJ.py
+++ b/fsf-server/modules/EXTRACT_RTF_OBJ.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Extract RTF objects

--- a/fsf-server/modules/EXTRACT_SWF.py
+++ b/fsf-server/modules/EXTRACT_SWF.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Process compressed SWF files

--- a/fsf-server/modules/EXTRACT_TAR.py
+++ b/fsf-server/modules/EXTRACT_TAR.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Extract files from TAR archive file

--- a/fsf-server/modules/EXTRACT_UPX.py
+++ b/fsf-server/modules/EXTRACT_UPX.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Unpack UPX packed binaries

--- a/fsf-server/modules/EXTRACT_VBA_MACRO.py
+++ b/fsf-server/modules/EXTRACT_VBA_MACRO.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Extract metadata for Office documents

--- a/fsf-server/modules/EXTRACT_ZIP.py
+++ b/fsf-server/modules/EXTRACT_ZIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Company: Emerson

--- a/fsf-server/modules/META_BASIC_INFO.py
+++ b/fsf-server/modules/META_BASIC_INFO.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Company: Emerson

--- a/fsf-server/modules/META_ELF.py
+++ b/fsf-server/modules/META_ELF.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+#
 # Author: Jason Batchelor
 # Company: Emerson
 # Description: Extract metadata associated with ELF payloads

--- a/fsf-server/modules/META_JAVA_CLASS.py
+++ b/fsf-server/modules/META_JAVA_CLASS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Get metadata concerning Java class files

--- a/fsf-server/modules/META_OOXML.py
+++ b/fsf-server/modules/META_OOXML.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Company: Emerson

--- a/fsf-server/modules/META_PDF.py
+++ b/fsf-server/modules/META_PDF.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Company: Emerson

--- a/fsf-server/modules/META_PE.py
+++ b/fsf-server/modules/META_PE.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Company: Emerson

--- a/fsf-server/modules/META_PE_SIGNATURE.py
+++ b/fsf-server/modules/META_PE_SIGNATURE.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Get metadata on the signature used to sign a PE file

--- a/fsf-server/modules/META_VT_INSPECT.py
+++ b/fsf-server/modules/META_VT_INSPECT.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jason Batchelor
 # Description: Search VirusTotal database based on computed hash of buffer

--- a/fsf-server/modules/SCAN_YARA.py
+++ b/fsf-server/modules/SCAN_YARA.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Jason Batchelor
 # Module used to scan files against our Yara signatures

--- a/fsf-server/modules/template.py
+++ b/fsf-server/modules/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author:
 # Description: 

--- a/fsf-server/processor.py
+++ b/fsf-server/processor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Process objects and sub objects according to disposition criteria.
 # Log all the results. 

--- a/fsf-server/scanner.py
+++ b/fsf-server/scanner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Base class for scanner framework.
 #


### PR DESCRIPTION
#23

Updated shebang line on all python files to: 
  #!/usr/bin/env python

This should allow analysts to run both FSF-Server and FSF-Client with python installed in non-default places on $PATH or with VIRTUALENV

h/t mpurzynski
