### PR TITLE
Allow fail over incase of multiple servers.

### DIFF
--- a/fsf-client/fsf_client.py
+++ b/fsf-client/fsf_client.py
@@ -58,16 +58,17 @@ class FSFClient:
 
 # Test connection to randomized server and rudimentary fail over
    def initiate_submission(self):
+      
       sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
       random.shuffle(self.server_list)
       attempts = 0
+      
       for server in self.server_list:
           success = 1
           try:
               sock.connect((server, self.port))
           except:
-              warning ='%s There was a problem connecting to %s on port %s. Trying another server. <WARN>' % (dt.now(), server, self.port)
+              warning ='%s There was a problem connecting to %s on port %s. Trying another server. <WARN>\n' % (dt.now(), server, self.port)
               self.issue_error(warning)
               success = 0
               attempts += 1

--- a/fsf-client/fsf_client.py
+++ b/fsf-client/fsf_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # FSF Client for sending information and generating a report
 #
@@ -52,12 +52,12 @@ class FSFClient:
          
          archive_options = ['none', 'file-on-alert', 'all-on-alert', 'all-the-files', 'all-the-things']
          if args.archive not in archive_options:
-            error = '\033[31m'+'%s Please specify a valid archive option: \'none\', \'file-on-alert\', \'all-on-alert\', \'all-the-files\' or \'all-the-things\'.\n' % dt.now()
+            error = '%s Please specify a valid archive option: \'none\', \'file-on-alert\', \'all-on-alert\', \'all-the-files\' or \'all-the-things\'.\n' % dt.now()
             self.issue_error(error)
             sys.exit(1)
 
 # Test connection to randomized server and rudimentary fail over
-   def test_server_connection(self):
+   def initiate_submission(self):
       sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
       random.shuffle(self.server_list)
@@ -67,7 +67,7 @@ class FSFClient:
           try:
               sock.connect((server, self.port))
           except:
-              warning ='\033[93m'+ '%s There was a problem connecting to %s on port %s. Trying another server. <WARN>' % (dt.now(), server, self.port)
+              warning ='%s There was a problem connecting to %s on port %s. Trying another server. <WARN>' % (dt.now(), server, self.port)
               self.issue_error(warning)
               success = 0
               attempts += 1
@@ -77,7 +77,7 @@ class FSFClient:
               break
           elif attempts == len(self.server_list):
               e = sys.exc_info()[0]
-              error = '\033[31m'+'%s There are not servers available to send files too. Error: %s\n' % (dt.now(), e)
+              error = '%s There are not servers available to send files too. Error: %s\n' % (dt.now(), e)
               self.issue_error(error)
 
 
@@ -93,7 +93,7 @@ class FSFClient:
          sock.sendall(buffer)
       except:
          e = sys.exc_info()[0]
-         error = '\033[31m'+'%s There was a problem sending file %s to %s on port %s. Error: %s\n' % (dt.now(), self.filename, self.host, self.port, e)
+         error = '%s There was a problem sending file %s to %s on port %s. Error: %s\n' % (dt.now(), self.filename, self.host, self.port, e)
          self.issue_error(error)
 
       finally:
@@ -128,7 +128,7 @@ class FSFClient:
 
       except:
          e = sys.exc_info()[0]
-         error = '\033[31m'+'%s There was a problem getting data for %s from %s on port %s. Error: %s' % (dt.now(), self.filename, self.host, self.port, e)
+         error = '%s There was a problem getting data for %s from %s on port %s. Error: %s' % (dt.now(), self.filename, self.host, self.port, e)
          self.issue_error(error)
 
    # Dump all subobjects returned by the scanner server
@@ -170,7 +170,7 @@ class FSFClient:
             f.write(error)
             f.close()
       else:
-         print error+'\033[0m'
+         print error
 
 if __name__ == '__main__':
 

--- a/fsf-client/fsf_client.py
+++ b/fsf-client/fsf_client.py
@@ -44,8 +44,8 @@ class FSFClient:
          self.suppress_report = suppress_report
          self.full = full
          self.file = file
-         # If multiple server candidates are given, we randomly choose one
-         self.host = random.choice(config.SERVER_CONFIG['IP_ADDRESS'])
+         # will hold host after verifying connection to server
+         self.host = ''
          self.port = config.SERVER_CONFIG['PORT']
          self.logfile = config.CLIENT_CONFIG['LOG_FILE']
          self.server_list = config.SERVER_CONFIG['IP_ADDRESS']

--- a/fsf-client/fsf_client.py
+++ b/fsf-client/fsf_client.py
@@ -200,4 +200,4 @@ if __name__ == '__main__':
       filename = os.path.basename(f.name)
       file = f.read()
       fsf = FSFClient(f.name, filename, args.delete, args.source, args.archive, args.suppress_report, args.full, file)
-      fsf.test_server_connection()
+      fsf.initiate_submission()


### PR DESCRIPTION
We are running multiple FSF servers and noticed that if the server selected at random is unable to handle the request that the file never makes it to another server. I modified our script to attempt a connection to a random server and only after making a successful connection sending the file. That way if a server doesn't respond we get a warning message and it continues on to the next random server. If no server is available it then raises an error.  We also colorized the errors which if you want I can remove them.
