### PR TITLE
converted the constants_pool object in META_JAVA_CLASS

### DIFF
--- a/fsf-server/modules/META_JAVA_CLASS.py
+++ b/fsf-server/modules/META_JAVA_CLASS.py
@@ -2,9 +2,9 @@
 #
 # Author: Jason Batchelor
 # Description: Get metadata concerning Java class files
-# Date: 01/26/2016
+# Date: 02/07/2017 (updated)
 '''
-   Copyright 2016 Emerson Electric Co.
+   Copyright 2017 Emerson Electric Co.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -40,7 +40,10 @@ def META_JAVA_CLASS(s, buff):
    options = classinfo_options()
    info = unpack_class(buff)
    META_DICT = classinfo.cli_simplify_classinfo(options, info)
-
+   _constants_pool = []
+   for x in META_DICT['constants_pool']:
+      _constants_pool.append({"index": x[0], "type": x[1], "value": x[2]})
+   META_DICT["constants_pool"] = _constants_pool
    return META_DICT
 
 if __name__ == '__main__':


### PR DESCRIPTION
Moved from a list of tuples of (int, str, str) to a list of dicts of {index:int, type:str, value:str} per discussion in #40 . This should alleviate issues where the tuple gets converted to a list of multiple object types by the python json library, however the resulting json can't be processed by Elasticsearch. 

Also updated the dates on the module to reflect the update and the new year. 