### PR TITLE
Moves pid path to conf file.

### DIFF
--- a/fsf-server/conf/config.py
+++ b/fsf-server/conf/config.py
@@ -8,6 +8,7 @@ import socket
 
 SCANNER_CONFIG = { 'LOG_PATH' : '/tmp',
                    'YARA_PATH' : '/FULL/PATH/TO/fsf/fsf-server/yara/rules.yara',
+                   'PID_PATH' : '/tmp/scanner.pid',
                    'EXPORT_PATH' : '/tmp',
                    'TIMEOUT' : 60,
                    'MAX_DEPTH' : 10 }

--- a/fsf-server/main.py
+++ b/fsf-server/main.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
    with open(daemon_logger, 'a') as fh:
       fh.write('%s Daemon given %s command\n' % (dt.now(), sys.argv[1]))
 
-   daemon = ScannerDaemon('/tmp/scanner.pid', stdin=daemon_logger, stdout=daemon_logger, stderr=daemon_logger)
+   daemon = ScannerDaemon(config.SCANNER_CONFIG['PID_PATH'], stdin=daemon_logger, stdout=daemon_logger, stderr=daemon_logger)
 
    if 'start' == sys.argv[1]:
       daemon.start()


### PR DESCRIPTION
I'd like to move the pid path to the config file. This makes it easier for distribution. For instance on Fedora and CentOS, pid paths should be under `/run/`. I'd rather not make the assumption that others want it there, but making it configurable with the same default as used today adds flexibility for everyone. =D