### PR TITLE
Sanitizing iframe src tag in misc_hexascii_pe_in_html.yara

### DIFF
--- a/fsf-server/yara/misc_hexascii_pe_in_html.yara
+++ b/fsf-server/yara/misc_hexascii_pe_in_html.yara
@@ -6,7 +6,7 @@ Example target...
 
 ...
 
-<iframe src="http://NtKrnlpa.cn/rc/" width=1 height=1 style="border:0"></iframe>
+<iframe src="hxxp://NtKrnlpa[.]cn/rc/" width=1 height=1 style="border:0"></iframe>
 </body></html><SCRIPT Language=VBScript><!--
 DropFileName = "svchost.exe"
 WriteData = "4D5A90000300000004000000FFFF0000B800000000000000400000000000000..


### PR DESCRIPTION
This change only affects the sig comments--there is no impact on signature functionality.

Hopefully this will prevent the fairly frequent occurrence of commercial AV flagging this signature as malicious due to the iframe src tag's url (facepalm AV)

ref #45