### PR TITLE
META_PE adjustments to ensure consistent response object types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-2/25/2017
+2/27/2017
 ---------
 * Merge PR#47 which addresses META_PE output inconsistencies during module exceptions. This should increase consistency in FSF outputs and remove barriers to indexing / storage in document oriented databases. 
+
+2/25/2017
+----------
+* Merged PR#46 which is minor tweak to the misc_hexascii_pe_in_html comments to help avoid some AV vendors flagging the rule file as malware. 
 
 2/09/2017
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2/25/2017
+---------
+* Merge PR#47 which addresses META_PE output inconsistencies during module exceptions. This should increase consistency in FSF outputs and remove barriers to indexing / storage in document oriented databases. 
+
 2/09/2017
 ---------
 * Merged PR#43 which moves the pidfile path (formerly hard coded into fsf-server.main) to the fsf-server.conf.config. This allows for more flexible deployment of FSF across multiple platforms. 

--- a/fsf-server/modules/META_PE.py
+++ b/fsf-server/modules/META_PE.py
@@ -134,12 +134,13 @@ def get_dllcharacteristics(pe):
 
 def get_resource_names(pe):
 
+   resource_names = []
+
    try: 
       pe.DIRECTORY_ENTRY_RESOURCE.entries
    except:
-      return 'None'
+      return resource_names
 
-   resource_names = []
    for res in pe.DIRECTORY_ENTRY_RESOURCE.entries:
       if res.name is not None:
          resource_names.append(res.name.__str__())
@@ -147,12 +148,13 @@ def get_resource_names(pe):
 
 def get_resource_types(pe):
 
+   resource_types = []
+
    try:
       pe.DIRECTORY_ENTRY_RESOURCE.entries
    except:
-      return 'None'
+      return resource_types
 
-   resource_types = []
    for res in pe.DIRECTORY_ENTRY_RESOURCE.entries:
       if res.id is not None:
          resource_types.append(enum_resources(res.id))
@@ -165,7 +167,7 @@ def get_exports(pe):
    try:
       pe.DIRECTORY_ENTRY_EXPORT.symbols
    except:
-      return 'None'
+      return my_exports
 
    for exp in pe.DIRECTORY_ENTRY_EXPORT.symbols:
       my_exports.append(exp.name)
@@ -179,7 +181,7 @@ def get_imports(pe):
    try:
       pe.DIRECTORY_ENTRY_IMPORT
    except:
-      return 'None'
+      return IMPORTS
 
    for entry in pe.DIRECTORY_ENTRY_IMPORT:
       my_imports = []
@@ -230,4 +232,5 @@ def META_PE(s, buff):
    return META_PE
 
 if __name__ == '__main__':
-   print META_PE(None, sys.stdin.read())
+    print META_PE(None, sys.stdin.read())
+

--- a/fsf-server/modules/META_PE.py
+++ b/fsf-server/modules/META_PE.py
@@ -196,7 +196,7 @@ def get_stringfileinfo(pe):
    try:
       pe.FileInfo
    except:
-      return 'None'
+      return STRINGFILEINFO
 
    for fi in pe.FileInfo:
       if fi.Key == 'StringFileInfo':


### PR DESCRIPTION
Updated several META_PE methods to ensure that they return consistent response objects per Issue #47  raised by @dcode. 