### PR TITLE
Explicitly cast value as string.

### DIFF
--- a/fsf-server/modules/META_JAVA_CLASS.py
+++ b/fsf-server/modules/META_JAVA_CLASS.py
@@ -42,7 +42,7 @@ def META_JAVA_CLASS(s, buff):
    META_DICT = classinfo.cli_simplify_classinfo(options, info)
    _constants_pool = []
    for x in META_DICT['constants_pool']:
-      _constants_pool.append({"index": x[0], "type": x[1], "value": x[2]})
+      _constants_pool.append({"index": x[0], "type": x[1], "value": str(x[2])})
    META_DICT["constants_pool"] = _constants_pool
    return META_DICT
 


### PR DESCRIPTION
Since the value could be any valid Java value type, cast it to a string. Without this, Elasticsearch cannot generate a valid mapping, since it could be an int in one record and a string in the next.

NOTE: not sure if this is needed anymore w/ the other changes. If not, just close the PR and I'll delete my fork.